### PR TITLE
Spelling and Capitalization

### DIFF
--- a/docs/source/firehol.rst
+++ b/docs/source/firehol.rst
@@ -16,8 +16,8 @@ For configuring the FireHOL IP Blocklists analyzer, the cortex configuration fil
 
 .. code-block:: python
 
-    FireholBlocklists {
-        blocklistspath="/tmp/fireholblocklists" # Path to blocklists cloned from github
+    FireHOLBlocklists {
+        blocklistpath="/tmp/fireholblocklists" # Path to blocklists cloned from github
         ignoredays="365" # Ignore lists older than x days - NOT IMPEMENTED YET
     }
 


### PR DESCRIPTION
The code in FireHOLBlocklists.json lists "FireHOLBlocklists" as the base config not "FireholBlocklists".
The code in firehol_blocklists.py (line 23) expects the application.conf file to contain 'config.blocklistpath' not 'config.blocklistspath'